### PR TITLE
Add Replicate demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # playgroundai/playground-v2.5-1024px-aesthetic Cog model
 
+[![Try a demo on Replicate](https://replicate.com/playgroundai/playground-v2.5-1024px-aesthetic/badge)](https://replicate.com/playgroundai/playground-v2.5-1024px-aesthetic)
+
 This is an implementation of the [playgroundai/playground-v2.5-1024px-aesthetic](https://huggingface.co/playgroundai/playground-v2.5-1024px-aesthetic) as a Cog model. [Cog packages machine learning models as standard containers.](https://github.com/replicate/cog)
 
 Run predictions:


### PR DESCRIPTION
This PR adds a badge with a link to your model on Replicate, making it easier for users to try it out. 

Feel free to close if you don't want this, but many model creators have found it helpful.